### PR TITLE
Prevent startup from running forever

### DIFF
--- a/django_asgi_lifespan/handler.py
+++ b/django_asgi_lifespan/handler.py
@@ -59,6 +59,7 @@ class LifespanASGIHandler(ASGIHandler):
                     await send(
                         LifespanStartupCompleteEvent(type="lifespan.startup.complete")
                     )
+                    return
                 case "lifespan.shutdown":
                     await self._process_lifespan_event(signals.asgi_shutdown, scope)
                     await send(


### PR DESCRIPTION
Because of the `while True`, if the `lifespan.startup` case never returns, awaiting the startup message will never finish.

I tried to see if this was standard behaviour in other ASGI applications, and at least Starlette does not follow this pattern and does return once `send` is awaited:

https://github.com/encode/starlette/blob/93494a46ee0f2e8b1eeafd12e466ebac15037b41/starlette/routing.py#L734-L736
