### PR TITLE
Test ASGI servers in CI using Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@
 !pyproject.toml
 !uv.lock
 !README.md
+!LICENSE
 
 !django_asgi_lifespan/**/*.py
 !tests/**/*.py

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -91,3 +91,14 @@ jobs:
           fail_ci_if_error: true
           files: coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  e2e-asgi-docker:
+    name: ASGI server e2e (Docker)
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run ASGI server e2e smoke tests
+        run: bash tests/e2e/run-e2e.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN --mount=type=cache,target=/opt/.cache/uv \
         --no-install-project
 
 # Copy source and install local package in development mode
-COPY pyproject.toml uv.lock README.md /usr/src/app/
+COPY pyproject.toml uv.lock README.md LICENSE /usr/src/app/
 COPY ./django_asgi_lifespan /usr/src/app/django_asgi_lifespan/
 COPY ./tests /usr/src/app/tests/
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -26,6 +26,12 @@ tasks:
       - uv run pytest --cov=./django_asgi_lifespan/ --cov-branch --cov-report=xml --cov-report=term-missing ./tests/
     silent: false
 
+  e2e:
+    desc: Run Dockerized ASGI server e2e smoke tests (requires Docker)
+    cmds:
+      - bash ./tests/e2e/run-e2e.sh
+    silent: false
+
   clean:
     desc: Clean build files
     cmds:

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -70,5 +70,10 @@ run_server hypercorn "/client-from-app-config" \
     uv run hypercorn --bind 0.0.0.0:8080 \
     django_test_application.asgi:application
 
+run_server granian "/client-from-app-config /client-from-scope-state" \
+    uv run granian --interface asgi \
+    --host 0.0.0.0 --port 8080 \
+    django_test_application.asgi:application
+
 echo
 echo ">> All servers passed"

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# End-to-end smoke test: boot the test Django app in Docker against each
+# supported ASGI server and verify both lifespan-managed endpoints respond.
+set -euo pipefail
+
+IMAGE=asgi-e2e:local
+CONTAINER=asgi-e2e
+PORT=8080
+HOST=127.0.0.1
+
+echo ">> Building image $IMAGE"
+docker build -t "$IMAGE" .
+
+run_server() {
+    local name=$1
+    shift
+    echo
+    echo "================================================================"
+    echo ">> Server: $name"
+    echo "================================================================"
+
+    docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+    docker run -d --rm --name "$CONTAINER" -p "$PORT:$PORT" \
+        --workdir /usr/src/app/tests/ "$IMAGE" "$@"
+
+    echo ">> Waiting up to 30s for $name to become ready"
+    for _ in $(seq 1 30); do
+        if curl -fsS -o /dev/null "http://$HOST:$PORT/client-from-app-config"; then
+            echo ">> $name is ready"
+            break
+        fi
+        sleep 1
+    done
+
+    if ! curl -fsS -o /dev/null "http://$HOST:$PORT/client-from-app-config"; then
+        echo ">> $name failed to become ready, container logs:"
+        docker logs "$CONTAINER" || true
+        docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+        exit 1
+    fi
+
+    echo ">> Hitting /client-from-app-config"
+    curl --fail-with-body --max-time 10 "http://$HOST:$PORT/client-from-app-config"
+    echo
+
+    echo ">> Hitting /client-from-scope-state"
+    curl --fail-with-body --max-time 10 "http://$HOST:$PORT/client-from-scope-state"
+    echo
+
+    docker stop "$CONTAINER" >/dev/null
+    echo ">> $name: OK"
+}
+
+run_server uvicorn \
+    uv run uvicorn django_test_application.asgi:application \
+    --host 0.0.0.0 --port 8080 --lifespan on
+
+echo
+echo ">> All servers passed"

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -13,6 +13,9 @@ IMAGE=asgi-e2e:local
 CONTAINER=asgi-e2e
 PORT=8080
 HOST=127.0.0.1
+# Readiness is always probed on the signal-based endpoint: it is the one
+# endpoint every server in this matrix supports.
+READINESS_ENDPOINT=/client-from-app-config
 
 echo ">> Building image $IMAGE"
 docker build -t "$IMAGE" .
@@ -22,8 +25,6 @@ run_server() {
     local name=$1
     local endpoints=$2
     shift 2
-    local first_endpoint
-    first_endpoint=$(echo "$endpoints" | awk '{print $1}')
 
     echo
     echo "================================================================"
@@ -35,20 +36,22 @@ run_server() {
         --workdir /usr/src/app/tests/ "$IMAGE" "$@"
 
     echo ">> Waiting up to 30s for $name to become ready"
+    local ready=
     for _ in $(seq 1 30); do
-        if curl -fsS -o /dev/null "http://$HOST:$PORT$first_endpoint"; then
-            echo ">> $name is ready"
+        if curl -fsS -o /dev/null "http://$HOST:$PORT$READINESS_ENDPOINT"; then
+            ready=1
             break
         fi
         sleep 1
     done
 
-    if ! curl -fsS -o /dev/null "http://$HOST:$PORT$first_endpoint"; then
+    if [[ -z $ready ]]; then
         echo ">> $name failed to become ready, container logs:"
         docker logs "$CONTAINER" || true
         docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
         exit 1
     fi
+    echo ">> $name is ready"
 
     for endpoint in $endpoints; do
         echo ">> Hitting $endpoint"
@@ -62,17 +65,17 @@ run_server() {
 
 run_server uvicorn "/client-from-app-config /client-from-scope-state" \
     uv run uvicorn django_test_application.asgi:application \
-    --host 0.0.0.0 --port 8080 --lifespan on
+    --host 0.0.0.0 --port "$PORT" --lifespan on
 
 # Hypercorn supports lifespan but not lifespan scope state, so only the
 # signal-based endpoint is exercised here. See docs/asgi.md.
 run_server hypercorn "/client-from-app-config" \
-    uv run hypercorn --bind 0.0.0.0:8080 \
+    uv run hypercorn --bind "0.0.0.0:$PORT" \
     django_test_application.asgi:application
 
 run_server granian "/client-from-app-config /client-from-scope-state" \
     uv run granian --interface asgi \
-    --host 0.0.0.0 --port 8080 \
+    --host 0.0.0.0 --port "$PORT" \
     django_test_application.asgi:application
 
 echo

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 # End-to-end smoke test: boot the test Django app in Docker against each
-# supported ASGI server and verify both lifespan-managed endpoints respond.
+# supported ASGI server and verify the lifespan-managed endpoints respond.
+#
+# Per docs/asgi.md, daphne is intentionally skipped here: it does not
+# implement the ASGI lifespan protocol at all (see django/daphne#264), so
+# no lifespan signal would ever fire. Hypercorn is exercised, but only on
+# the signal-based endpoint, because hypercorn does not propagate
+# lifespan scope state to HTTP scopes (see pgjones/hypercorn#107).
 set -euo pipefail
 
 IMAGE=asgi-e2e:local
@@ -11,9 +17,14 @@ HOST=127.0.0.1
 echo ">> Building image $IMAGE"
 docker build -t "$IMAGE" .
 
+# Usage: run_server NAME "ENDPOINT [ENDPOINT ...]" SERVER_CMD...
 run_server() {
     local name=$1
-    shift
+    local endpoints=$2
+    shift 2
+    local first_endpoint
+    first_endpoint=$(echo "$endpoints" | awk '{print $1}')
+
     echo
     echo "================================================================"
     echo ">> Server: $name"
@@ -25,35 +36,39 @@ run_server() {
 
     echo ">> Waiting up to 30s for $name to become ready"
     for _ in $(seq 1 30); do
-        if curl -fsS -o /dev/null "http://$HOST:$PORT/client-from-app-config"; then
+        if curl -fsS -o /dev/null "http://$HOST:$PORT$first_endpoint"; then
             echo ">> $name is ready"
             break
         fi
         sleep 1
     done
 
-    if ! curl -fsS -o /dev/null "http://$HOST:$PORT/client-from-app-config"; then
+    if ! curl -fsS -o /dev/null "http://$HOST:$PORT$first_endpoint"; then
         echo ">> $name failed to become ready, container logs:"
         docker logs "$CONTAINER" || true
         docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
         exit 1
     fi
 
-    echo ">> Hitting /client-from-app-config"
-    curl --fail-with-body --max-time 10 "http://$HOST:$PORT/client-from-app-config"
-    echo
-
-    echo ">> Hitting /client-from-scope-state"
-    curl --fail-with-body --max-time 10 "http://$HOST:$PORT/client-from-scope-state"
-    echo
+    for endpoint in $endpoints; do
+        echo ">> Hitting $endpoint"
+        curl --fail-with-body --max-time 10 "http://$HOST:$PORT$endpoint"
+        echo
+    done
 
     docker stop "$CONTAINER" >/dev/null
     echo ">> $name: OK"
 }
 
-run_server uvicorn \
+run_server uvicorn "/client-from-app-config /client-from-scope-state" \
     uv run uvicorn django_test_application.asgi:application \
     --host 0.0.0.0 --port 8080 --lifespan on
+
+# Hypercorn supports lifespan but not lifespan scope state, so only the
+# signal-based endpoint is exercised here. See docs/asgi.md.
+run_server hypercorn "/client-from-app-config" \
+    uv run hypercorn --bind 0.0.0.0:8080 \
+    django_test_application.asgi:application
 
 echo
 echo ">> All servers passed"

--- a/uv.lock
+++ b/uv.lock
@@ -708,7 +708,7 @@ wheels = [
 
 [[package]]
 name = "django-asgi-lifespan"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "asgiref" },
@@ -796,7 +796,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2616,8 +2616,8 @@ name = "taskgroup"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/8d/e218e0160cc1b692e6e0e5ba34e8865dbb171efeb5fc9a704544b3020605/taskgroup-0.2.2.tar.gz", hash = "sha256:078483ac3e78f2e3f973e2edbf6941374fbea81b9c5d0a96f51d297717f4752d", size = 11504, upload-time = "2025-01-03T09:24:13.761Z" }
 wheels = [


### PR DESCRIPTION
Adds a Docker-based CI job that boots uvicorn, hypercorn, and granian against the test app and verifies the lifespan endpoints respond. Closes #93.